### PR TITLE
add getmeasurements with null fix

### DIFF
--- a/app/src/main/java/com/example/cocktailme/RecipeDetailsActivity.java
+++ b/app/src/main/java/com/example/cocktailme/RecipeDetailsActivity.java
@@ -112,6 +112,25 @@ public class RecipeDetailsActivity extends AppCompatActivity {
                     }
                 });
     }
+    public String getMeasurements(JSONArray drinks) throws JSONException {
+        String measurements = "";
+        for (int i = 1; i < 16; i++) {
+            String curr = "strIngredient" + i;
+            String measure = "strMeasure" + i;
+            if (drinks.getJSONObject(0).getString(curr) != null && drinks.getJSONObject(0).getString(measure) != null
+            ) {
+                Log.i(TAG, drinks.getJSONObject(0).getString(measure));
+                Log.i("Check", drinks.getJSONObject(0).getString(curr));
+                if (!drinks.getJSONObject(0).getString(curr).equals("null") && !drinks.getJSONObject(0).getString(measure).equals("null")) {
+                    measurements += drinks.getJSONObject(0).getString(measure) + " " + drinks.getJSONObject(0).getString(curr) + "\n ";
+                }
+            } else {
+                measurements = "Measurements not found";
+            }
+        }
+        return measurements;
+    }
+
 
 
     private void queryRatingsForCocktailID() {


### PR DESCRIPTION
### Summary:
_Context_ - This is part of a larger effort to create an Android app that takes in a list of ingredients and returns a list of cocktail recipes that can be made using them.

_Reference_ - [RapidAPI](https://rapidapi.com/thecocktaildb/api/the-cocktail-db) and [TheCocktailDB](https://www.thecocktaildb.com/api.php)

_This Diff_ - adds the getMeasurements function so that values are only added from the JSONObject if they are not null

### Test Plan:
BEFORE:
<img width="397" alt="Screen Shot 2022-07-21 at 12 55 32 PM" src="https://user-images.githubusercontent.com/66920319/180304165-947df21b-c6bf-4150-9c7a-20484bb9df97.png">
AFTER:
<img width="402" alt="Screen Shot 2022-07-21 at 12 56 37 PM" src="https://user-images.githubusercontent.com/66920319/180304108-5c80be79-8213-4c7b-89c2-bdaab7615230.png">

